### PR TITLE
Add additional documentation for available actions

### DIFF
--- a/core/manifests/README.md
+++ b/core/manifests/README.md
@@ -2,6 +2,8 @@
 
 A manifest in `Comtrya` is a collection of actions and dependencies.
 
+This manifest file can be placed in any location.
+
 Let's assume we have the file `one.yaml`, which looks like this:
 
 ```
@@ -11,7 +13,7 @@ actions:
   command: echo Hello, world!
 ```
 
-This manifest performs a single task, which uses the `command.run` action and provides the command to be run which is `echo Hello, world!`
+This manifest performs a single task, which uses the `command.run` [action](actions/) and provides the command to be run which is `echo Hello, world!`
 
 Now, let's define `two.yaml` which contains a depdency on `one.yaml`
 

--- a/core/manifests/actions/README.md
+++ b/core/manifests/actions/README.md
@@ -2,6 +2,19 @@
 
 `Comtrya`supports at the moment the following actions:
 
+| Action | Alias| Description |
+| :--- | :--- | :--- |
+| `command.run` | `cmd.run` | Runs a given command |
+| `package.install` | `package.installed` | Installs a given package from a provider |
+| `directory.create` | `dir.create` | Creates a given directory |
+| `directory.copy` | `dir.copy` | Copies a given directory |
+| `file.copy` |  | Copies a given file |
+| `file.link` |  | Creates a link to a specific file |
+| `file.download` |  | Downloads a file from a given source |
+| `binary.github` | `bin.gh` | Downloads a release binary |
+| `git.clone` | | Clones a git repository |
+| `user.add` | | Creates a given user |
+
 {% page-ref page="commands/" %}
 
 {% page-ref page="files-and-directories/" %}

--- a/core/manifests/actions/binaries/binary.github.md
+++ b/core/manifests/actions/binaries/binary.github.md
@@ -4,6 +4,8 @@ description: 'Action: binary.github'
 
 # Run
 
+Downloads a binary from a github `repository` into a local `directory`.
+
 | Key          | Typ    | Optional | Description                           |
 | :----------- | :----- | :------- | :------------------------------------ |
 | `action`     | string | no       | `binary.github`                       |

--- a/core/manifests/actions/files-and-directories/directory.copy.md
+++ b/core/manifests/actions/files-and-directories/directory.copy.md
@@ -4,9 +4,11 @@ description: 'Action: directory.copy'
 
 # Directory
 
+Creates or copies a given directory into a local location.
+
 | Key | Type | Optional | Description |
 | :--- | :--- | :--- | :--- |
-| `action` | string | no | `directory.copy` |
+| `action` | string | no | `directory.copy` or `directory.create` |
 | `from` | string | no | source file |
 | `to` | string | no | destination file |
 

--- a/core/manifests/actions/files-and-directories/file.copy.md
+++ b/core/manifests/actions/files-and-directories/file.copy.md
@@ -4,13 +4,14 @@ description: 'Action: file.copy'
 
 # File
 
-| Key        | Type   | Optional | Description                                                                                       |
-| :--------- | :----- | :------- | :------------------------------------------------------------------------------------------------ |
-| `action`   | string | no       | `file.copy`                                                                                       |
-| `from`     | string | no       | source file                                                                                       |
-| `to`       | string | no       | destination file                                                                                  |
-| `template` | bool   | yes      | renderes files using [context providers](../../../contexts/context-provider.md), Default: `false` |
-| `chmod`    | int    | yes      | octal permissions                                                                                 |
+| Key          | Type   | Optional | Description                                                                                       |
+| :----------- | :----- | :------- | :------------------------------------------------------------------------------------------------ |
+| `action`     | string | no       | `file.copy`                                                                                       |
+| `from`       | string | no       | source file                                                                                       |
+| `to`         | string | no       | destination file                                                                                  |
+| `template`   | bool   | yes      | renderes files using [context providers](../../../contexts/context-provider.md), Default: `false` |
+| `chmod`      | int    | yes      | octal permissions                                                                                 |
+| `passphrase` | string | yes      | if set, decrypt files with the given passphrase                                                   |
 
 ### Example
 


### PR DESCRIPTION
Add actions and detailed information to some actions.
Also adds the encryption documentation to `file.copy`

Closes #2 